### PR TITLE
Feat/multithreading

### DIFF
--- a/include/Scene.hpp
+++ b/include/Scene.hpp
@@ -14,11 +14,10 @@
 
 #include <vector>
 #include <memory>
-#include <thread>
+#include <string>
+#include <iosfwd>
 #include <atomic>
 #include <mutex>
-#include <chrono>
-#include <iomanip>
 
 namespace RayTracer {
 

--- a/include/Scene.hpp
+++ b/include/Scene.hpp
@@ -14,6 +14,11 @@
 
 #include <vector>
 #include <memory>
+#include <thread>
+#include <atomic>
+#include <mutex>
+#include <chrono>
+#include <iomanip>
 
 namespace RayTracer {
 
@@ -36,6 +41,8 @@ class Scene
         Math::Vector3d average_light(std::vector<Math::Vector3d> light_contributions) const;
         double clamp_color(double x) const;
         void write_color(const Math::Vector3d &color, std::string &output) const;
+        void renderChunk(std::vector<std::vector<Math::Vector3d>> &pixels, std::atomic<int> &columns_rendered, std::mutex &cerr_mutex, int start_col, int end_col) const;
+        std::string serializeBuffer(const std::vector<std::vector<Math::Vector3d>> &pixels) const;
     public:
         Scene(double brightness = 0.9, int max_depth = 4) : brightness(brightness), max_depth(max_depth) {}
         ~Scene() = default;

--- a/src/RayTracer/Scene.cpp
+++ b/src/RayTracer/Scene.cpp
@@ -110,26 +110,58 @@ void Scene::write_color(const Math::Vector3d &color, std::string &output) const
 
 void Scene::render(std::ostream &output) const
 {
-    std::string _final_output = "P3\n" + std::to_string(width) + " " + std::to_string(height) + "\n255\n";
+    int num_threads = std::max(1, static_cast<int>(std::thread::hardware_concurrency()) - 1); //leave one core free
+    std::cerr << "Rendering " << width << "x" << height << " image using " << num_threads << " threads...\n";
 
-    int percentage = 0;
-    int new_percentage = 0;
-    for (int j = height - 1; j >= 0; j--) {
-        new_percentage = (height - j) * 100 / height;
-        if (new_percentage != percentage) {
-            percentage = new_percentage;
-            std::cerr << "\rRendering: " << percentage << "%";
-        }
+    std::vector<std::vector<Math::Vector3d>> pixels(height, std::vector<Math::Vector3d>(width)); //2D vector to store pixel colors
+    std::atomic<int> columns_rendered{0};
+    std::mutex cerr_mutex; //we use a mutex to protect cerr output because multiple threads will be writing to cerr at the same time, and we want to avoid interleaving of output which can make it unreadable. By locking the mutex before writing to cerr and unlocking it afterwards, we ensure that only one thread writes to cerr at a time, keeping the output clean and coherent.
+    int cols_per_thread = (width + num_threads - 1) / num_threads; //calculate how many columns each thread should render (rounding up)
 
-        for (unsigned int i = 0; i < width; i++) {
+    auto t_start = std::chrono::high_resolution_clock::now();
+
+    std::vector<std::thread> threads;
+    threads.reserve(num_threads);
+    for (int t = 0; t < num_threads; t++) {
+        int start_col = t * cols_per_thread;
+        int end_col = (t == num_threads - 1) ? static_cast<int>(width) : start_col + cols_per_thread; //last thread takes any remaining columns
+        threads.emplace_back(&Scene::renderChunk, this, std::ref(pixels), std::ref(columns_rendered), std::ref(cerr_mutex), start_col, end_col);
+    }
+    for (auto &thread : threads)
+        thread.join(); //wait for all threads to finish
+
+    auto t_end = std::chrono::high_resolution_clock::now();
+    double elapsed = std::chrono::duration<double>(t_end - t_start).count();
+    std::cerr << "\nDone in " << std::fixed << std::setprecision(2) << elapsed << " s.\n";
+
+    output << serializeBuffer(pixels);
+}
+
+void Scene::renderChunk(std::vector<std::vector<Math::Vector3d>> &pixels, std::atomic<int> &columns_rendered, std::mutex &cerr_mutex, int start_col, int end_col) const
+{
+    for (int i = start_col; i < end_col; i++) {
+        for (int j = static_cast<int>(height) - 1; j >= 0; j--) {
             double u = static_cast<double>(i) / (width - 1);
             double v = static_cast<double>(j) / (height - 1);
             Ray ray = _camera.ray(u, v);
-            Math::Vector3d color = traceRay(ray, 0);
-            write_color(color, _final_output);
+            pixels[j][i] = traceRay(ray, 0);
+        }
+        int done = ++columns_rendered;
+        // hold the lock only for the print, release immediately after
+        {
+            std::lock_guard<std::mutex> lock(cerr_mutex);
+            std::cerr << "\rRendering: " << std::fixed << std::setprecision(2) << (done * 100.0 / width) << "% (" << done << "/" << width << " columns)" << std::flush;
         }
     }
-    output << _final_output;
+}
+
+std::string Scene::serializeBuffer(const std::vector<std::vector<Math::Vector3d>> &pixels) const
+{
+    std::string ppm = "P3\n" + std::to_string(width) + " " + std::to_string(height) + "\n255\n";
+    for (int j = static_cast<int>(height) - 1; j >= 0; j--)
+        for (int i = 0; i < static_cast<int>(width); i++)
+            write_color(pixels[j][i], ppm);
+    return ppm;
 }
 
 }

--- a/src/RayTracer/Scene.cpp
+++ b/src/RayTracer/Scene.cpp
@@ -147,8 +147,8 @@ void Scene::renderChunk(std::vector<std::vector<Math::Vector3d>> &pixels, std::a
 {
     for (int i = start_col; i < end_col; i++) {
         for (int j = static_cast<int>(height) - 1; j >= 0; j--) {
-            double u = static_cast<double>(i) / (width - 1);
-            double v = static_cast<double>(j) / (height - 1);
+            double u = (width == 1) ? 0.0 : static_cast<double>(i) / (width - 1);
+            double v = (height == 1) ? 0.0 : static_cast<double>(j) / (height - 1);
             Ray ray = _camera.ray(u, v);
             pixels[j][i] = traceRay(ray, 0);
         }

--- a/src/RayTracer/Scene.cpp
+++ b/src/RayTracer/Scene.cpp
@@ -113,13 +113,16 @@ void Scene::write_color(const Math::Vector3d &color, std::string &output) const
 
 void Scene::render(std::ostream &output) const
 {
+    if (width == 0 || height == 0)
+        return;
     int num_threads = std::max(1, static_cast<int>(std::thread::hardware_concurrency()) - 1); //leave one core free
+    num_threads = std::min(num_threads, static_cast<int>(width)); //cap to width: more threads than columns would cause out-of-bounds writes
     std::cerr << "Rendering " << width << "x" << height << " image using " << num_threads << " threads...\n";
 
     std::vector<std::vector<Math::Vector3d>> pixels(height, std::vector<Math::Vector3d>(width)); //2D vector to store pixel colors
     std::atomic<int> columns_rendered{0};
     std::mutex cerr_mutex; //we use a mutex to protect cerr output because multiple threads will be writing to cerr at the same time, and we want to avoid interleaving of output which can make it unreadable. By locking the mutex before writing to cerr and unlocking it afterwards, we ensure that only one thread writes to cerr at a time, keeping the output clean and coherent.
-    int cols_per_thread = (width + num_threads - 1) / num_threads; //calculate how many columns each thread should render (rounding up)
+    int cols_per_thread = (static_cast<int>(width) + num_threads - 1) / num_threads; //calculate how many columns each thread should render (rounding up)
 
     auto t_start = std::chrono::high_resolution_clock::now();
 

--- a/src/RayTracer/Scene.cpp
+++ b/src/RayTracer/Scene.cpp
@@ -153,10 +153,13 @@ void Scene::renderChunk(std::vector<std::vector<Math::Vector3d>> &pixels, std::a
             pixels[j][i] = traceRay(ray, 0);
         }
         int done = ++columns_rendered;
-        // hold the lock only for the print, release immediately after
-        {
-            std::lock_guard<std::mutex> lock(cerr_mutex);
-            std::cerr << "\rRendering: " << std::fixed << std::setprecision(2) << (done * 100.0 / width) << "% (" << done << "/" << width << " columns)" << std::flush;
+        int print_interval = std::max(1, static_cast<int>(width) / 100); //print every ~1% of columns to avoid flooding the log
+        if (done % print_interval == 0 || done == static_cast<int>(width)) {
+            // hold the lock only for the print, release immediately after
+            {
+                std::lock_guard<std::mutex> lock(cerr_mutex);
+                std::cerr << "\rRendering: " << std::fixed << std::setprecision(2) << (done * 100.0 / width) << "% (" << done << "/" << width << " columns)" << std::flush;
+            }
         }
     }
 }

--- a/src/RayTracer/Scene.cpp
+++ b/src/RayTracer/Scene.cpp
@@ -12,6 +12,9 @@
 #include <limits>
 #include <memory>
 #include <vector>
+#include <thread>
+#include <chrono>
+#include <iomanip>
 
 namespace RayTracer {
 void Scene::addShape(const std::shared_ptr<IShape> &object)


### PR DESCRIPTION
## Add multithreaded rendering

Replaces the single-threaded render loop with a column-per-core CPU multithreading strategy.
The column range is divided among `N-1` hardware threads (leaving one core free for the OS),
each writing to an exclusive slice of a shared pixel buffer. After all threads join, the buffer
is serialized to PPM.

This Fixes #28 